### PR TITLE
Specify library dependencies in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Wraps knolleary's pubsubclient for MQTT communication.
 category=Communication
 url=https://github.com/Losant/losant-mqtt-arduino
 architectures=*
+depends=PubSubClient


### PR DESCRIPTION
Specifying the library dependencies in the `depends` field of library.properties causes the Arduino Library Manager (Arduino IDE 1.8.10 and newer) to offer to install any missing dependencies during installation of this library.

`arduino-cli lib install` will automatically install the dependencies (arduino-cli 0.7.0 and newer).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format

NOTE: I left off the ArduinoJson library because losant-mqtt-arduino is incompatible with the 6.x.x versions of ArduinoJson (https://github.com/Losant/losant-mqtt-arduino/issues/13) and the Arduino Library Manager dependencies system currently only allows for installing the newest version of the dependencies. Once specifying dependency versions is supported, or losant-mqtt-arduino is updated to be compatible with the modern versions of ArduinoJson, it should be added to the `depends` field.