### PR TITLE
ArduinoJson 6 support, PubSubClient to MQTT Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Losant IoT, Inc
+Copyright (c) 2020 Losant IoT, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ Json object with keys and values. Refer to the [ArduinoJson](https://github.com/
 library for detailed documentation.
 
 ```C
-StaticJsonBuffer<100> jsonBuffer;
-JsonObject& state = jsonBuffer.createObject();
+StaticJsonDocument<200> jsonBuffer;
+JsonObject state = jsonBuffer.to<JsonObject>();
 state["temperature"] = 72;
 
 // Send the state to Losant.

--- a/README.md
+++ b/README.md
@@ -50,13 +50,7 @@ specific installation instructions.
 
 You’ll possibly hit the default MQTT packet size limit defined in the Losant Arduino MQTT Client library. Unfortunately the packet is blocked before reaching any of your code, so it’s hard to debug. It simply looks like the command was never received. For example:
 
-`{ "foo" : "bar" }` works, whereas `{ "somethingLarger" : "with a longer value" }` doesn’t work. This is because the default packet size is 256, which provides enough room for the command meta info and a small payload. Fortunately, this is easy to fix:
-
-1. Open the `LosantDevice.h` file from the Arduino libraries folder. On a Mac, this will be located at `~/Documents/Arduino/libraries/losant-mqtt-arduino/src/LosantDevice.h`.
-1. Edit the `MQTT_MAX_PACKET_SIZE` to something larger.
-1. Recompile and re-upload the firmware to the device.
-
-If you plan on sending even larger payloads, you can increase the value as needed. Just remember many boards don’t have a ton of memory, and the entire payload will have to fit.
+`{ "foo" : "bar" }` works, whereas `{ "somethingLarger" : "with a longer value" }` doesn’t work. This is because the default packet size is 256, which provides enough room for the command meta info and a small payload. Fortunately, this is easily fixed by defining a larger value for `MQTT_MAX_PACKET_SIZE` in your Arduino code.
   
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Once installed, using the library requires a single include directive.
 
 The Losant Arduino MQTT client depends on
 [ArduinoJson](https://github.com/bblanchon/ArduinoJson)
-and [PubSubClient](https://github.com/knolleary/pubsubclient). These libraries
+and [MQTT Client](https://github.com/256dpi/arduino-mqtt). These libraries
 must be installed before using the Losant MQTT client.  When using Platform.io,
 these dependencies are installed automatically, but when using the Arduino IDE
 they must be installed manually.  Please refer to their documentation for
@@ -48,15 +48,16 @@ specific installation instructions.
 
 ### Important Considerations
 
-You’ll likely hit the default MQTT packet size limit defined in the underlying [PubSubClient](https://github.com/knolleary/pubsubclient) library. Unfortunately the packet is blocked before reaching any of your code, so it’s hard to debug. It simply looks like the command was never received. For example:
+You’ll possibly hit the default MQTT packet size limit defined in the Losant Arduino MQTT Client library. Unfortunately the packet is blocked before reaching any of your code, so it’s hard to debug. It simply looks like the command was never received. For example:
 
-`{ "foo" : "bar" }` works, whereas `{ "somethingLarger" : "with a longer value" }` doesn’t work. This is because the default packet size is 128, which provides enough room for the command meta info and a small payload. Fortunately, this is easy to fix:
+`{ "foo" : "bar" }` works, whereas `{ "somethingLarger" : "with a longer value" }` doesn’t work. This is because the default packet size is 256, which provides enough room for the command meta info and a small payload. Fortunately, this is easy to fix:
 
-1. Open the `pubsubclient.h` file from the Arduino libraries folder. On a Mac, this will be located at `~/Documents/Arduino/libraries/pubsubclient/src/PubSubClient.h`.
-1. Edit the `MQTT_MAX_PACKET_SIZE` to something larger (Increasing it to 256 seems to work pretty well).
+1. Open the `LosantDevice.h` file from the Arduino libraries folder. On a Mac, this will be located at `~/Documents/Arduino/libraries/losant-mqtt-arduino/src/LosantDevice.h`.
+1. Edit the `MQTT_MAX_PACKET_SIZE` to something larger.
 1. Recompile and re-upload the firmware to the device.
 
 If you plan on sending even larger payloads, you can increase the value as needed. Just remember many boards don’t have a ton of memory, and the entire payload will have to fit.
+  
 
 ## Example
 
@@ -138,8 +139,8 @@ void buttonPressed() {
 
   // Losant uses a JSON protocol. Construct the simple state object.
   // { "button" : true }
-  StaticJsonBuffer<200> jsonBuffer;
-  JsonObject& root = jsonBuffer.createObject();
+  StaticJsonDocument<200> jsonBuffer;
+  JsonObject root = jsonBuffer.to<JsonObject>();
   root["button"] = true;
 
   // Send the state to Losant.

--- a/examples/arduino-wifi-shield-101/arduino-wifi-shield-101.ino
+++ b/examples/arduino-wifi-shield-101/arduino-wifi-shield-101.ino
@@ -107,8 +107,8 @@ void buttonPressed() {
 
   // Losant uses a JSON protocol. Construct the simple state object.
   // { "button" : true }
-  StaticJsonBuffer<200> jsonBuffer;
-  JsonObject& root = jsonBuffer.createObject();
+  StaticJsonDocument<200> jsonBuffer;
+  JsonObject root = jsonBuffer.to<JsonObject>();
   root["button"] = true;
 
   // Send the state to Losant.
@@ -128,7 +128,6 @@ void loop() {
 
   if(!device.connected()) {
     Serial.println("Disconnected from Losant");
-    Serial.println(device.mqttClient.state());
     toReconnect = true;
   }
 

--- a/examples/esp8266/esp8266.ino
+++ b/examples/esp8266/esp8266.ino
@@ -66,7 +66,9 @@ void connect() {
     Serial.print(".");
   }
 
-  // do not verify tls certificate
+  // With setInsecure() ou can tell BearSSL not to check the
+  // certificate of the server.  In this mode it will accept ANY certificate,
+  // which is subject to man-in-the-middle (MITM) attacks.
   // check the following example for methods to verify the server:
   // https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
   wifiClient.setInsecure();

--- a/examples/esp8266/esp8266.ino
+++ b/examples/esp8266/esp8266.ino
@@ -7,11 +7,13 @@
  * Button connected to pin 14.
  * LED connected to pin 12.
  *
- * Copyright (c) 2016 Losant. All rights reserved.
+ * Copyright (c) 2020 Losant. All rights reserved.
  * http://losant.com
  */
 
 #include <ESP8266WiFi.h>
+#include <WiFiClientSecure.h>
+#include <time.h>
 #include <Losant.h>
 
 // WiFi credentials.
@@ -28,12 +30,49 @@ const int LED_PIN = 12;
 
 bool ledState = false;
 
-WiFiClientSecure wifiClient;
+// Cert taken from 
+// https://github.com/Losant/losant-mqtt-ruby/blob/master/lib/losant_mqtt/RootCA.crt
+static const char digicert[] PROGMEM = R"EOF(
+-----BEGIN CERTIFICATE-----
+MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD
+QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT
+MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j
+b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB
+CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97
+nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt
+43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P
+T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4
+gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO
+BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR
+TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw
+DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr
+hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg
+06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF
+PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls
+YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk
+CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
+-----END CERTIFICATE-----
+)EOF";
 
-// For an unsecure connection to Losant.
-// WiFiClient wifiClient;
+BearSSL::WiFiClientSecure wifiClient;
 
 LosantDevice device(LOSANT_DEVICE_ID);
+
+// Set time via NTP, as required for x.509 validation
+void setClock() {
+  configTime(3 * 3600, 0, "pool.ntp.org", "time.nist.gov");
+
+  time_t now = time(nullptr);
+  while (now < 8 * 3600 * 2) {
+    delay(500);
+    now = time(nullptr);
+  }
+  struct tm timeinfo;
+  gmtime_r(&now, &timeinfo);
+}
 
 void toggle() {
   Serial.println("Toggling LED.");
@@ -66,12 +105,12 @@ void connect() {
     Serial.print(".");
   }
 
-  // With setInsecure() ou can tell BearSSL not to check the
-  // certificate of the server.  In this mode it will accept ANY certificate,
-  // which is subject to man-in-the-middle (MITM) attacks.
-  // check the following example for methods to verify the server:
-  // https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
-  wifiClient.setInsecure();
+  // Validating  the SSL for for a secure connection you must
+  // set trust anchor, as well as set the time.
+  BearSSL::X509List cert(digicert);
+  wifiClient.setTrustAnchors(&cert);
+  setClock();
+  
 
   Serial.println("");
   Serial.println("WiFi connected");
@@ -83,9 +122,6 @@ void connect() {
   Serial.print("Connecting to Losant...");
 
   device.connectSecure(wifiClient, LOSANT_ACCESS_KEY, LOSANT_ACCESS_SECRET);
-
-  // For an unsecure connection.
-  // device.connect(wifiClient, LOSANT_ACCESS_KEY, LOSANT_ACCESS_SECRET);
 
   while(!device.connected()) {
     delay(500);

--- a/examples/esp8266/esp8266.ino
+++ b/examples/esp8266/esp8266.ino
@@ -66,6 +66,11 @@ void connect() {
     Serial.print(".");
   }
 
+  // do not verify tls certificate
+  // check the following example for methods to verify the server:
+  // https://github.com/esp8266/Arduino/blob/master/libraries/ESP8266WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+  wifiClient.setInsecure();
+
   Serial.println("");
   Serial.println("WiFi connected");
   Serial.println("IP address: ");
@@ -106,8 +111,8 @@ void buttonPressed() {
 
   // Losant uses a JSON protocol. Construct the simple state object.
   // { "button" : true }
-  StaticJsonBuffer<200> jsonBuffer;
-  JsonObject& root = jsonBuffer.createObject();
+  StaticJsonDocument<200> jsonBuffer;
+  JsonObject root = jsonBuffer.to<JsonObject>();
   root["button"] = true;
 
   // Send the state to Losant.
@@ -127,7 +132,6 @@ void loop() {
 
   if(!device.connected()) {
     Serial.println("Disconnected from Losant");
-    Serial.println(device.mqttClient.state());
     toReconnect = true;
   }
 

--- a/examples/mkr1010/mkr1010.ino
+++ b/examples/mkr1010/mkr1010.ino
@@ -1,0 +1,150 @@
+/**
+ * Example that connects an Arduino MKR 1010 to the Losant
+ * IoT platform. This example reports state to Losant whenever a button is
+ * pressed. It also listens for the "toggle" command to turn the LED on and off.
+ *
+ * This example assumes the following connections:
+ * Button connected to pin 14.
+ * LED connected to pin 12.
+ *
+ * Copyright (c) 2020 Losant. All rights reserved.
+ * http://losant.com
+ */
+
+#include <WiFiNINA.h>
+#include <Losant.h>
+
+// WiFi credentials.
+const char* WIFI_SSID = "ssid";
+const char* WIFI_PASS = "pass";
+
+// Losant credentials.
+const char* LOSANT_DEVICE_ID = "LOSANT_DEVICE_ID";
+const char* LOSANT_ACCESS_KEY = "LOSANT_ACCESS_KEY";
+const char* LOSANT_ACCESS_SECRET = "LOSANT_ACCESS_SECRET";
+
+const int BUTTON_PIN = 14;
+const int LED_PIN = 12;
+
+bool ledState = false;
+
+WiFiSSLClient wifiClient;
+
+// For an unsecure connection to Losant.
+// WiFiClient wifiClient;
+
+LosantDevice device(LOSANT_DEVICE_ID);
+
+void toggle() {
+  Serial.println("Toggling LED.");
+  ledState = !ledState;
+  digitalWrite(LED_PIN, ledState ? HIGH : LOW);
+}
+
+// Called whenever the device receives a command from the Losant platform.
+void handleCommand(LosantCommand *command) {
+  Serial.print("Command received: ");
+  Serial.println(command->name);
+
+  if(strcmp(command->name, "toggle") == 0) {
+    toggle();
+  }
+}
+
+void connect() {
+
+  // Connect to Wifi.
+  Serial.println();
+  Serial.println();
+  Serial.print("Connecting to ");
+  Serial.println(WIFI_SSID);
+
+  WiFi.begin(WIFI_SSID, WIFI_PASS);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print(".");
+  }
+
+
+  Serial.println("");
+  Serial.println("WiFi connected");
+  Serial.println("IP address: ");
+  Serial.println(WiFi.localIP());
+
+  // Connect to Losant.
+  Serial.println();
+  Serial.print("Connecting to Losant...");
+
+  device.connectSecure(wifiClient, LOSANT_ACCESS_KEY, LOSANT_ACCESS_SECRET);
+
+  // For an unsecure connection.
+  // device.connect(wifiClient, LOSANT_ACCESS_KEY, LOSANT_ACCESS_SECRET);
+
+  while(!device.connected()) {
+    delay(500);
+    Serial.print(".");
+  }
+
+  Serial.println("Connected!");
+}
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial) { }
+  pinMode(BUTTON_PIN, INPUT);
+  pinMode(LED_PIN, OUTPUT);
+
+  // Register the command handler to be called when a command is received
+  // from the Losant platform.
+  device.onCommand(&handleCommand);
+
+  connect();
+}
+
+void buttonPressed() {
+  Serial.println("Button Pressed!");
+
+  // Losant uses a JSON protocol. Construct the simple state object.
+  // { "button" : true }
+  StaticJsonDocument<200> jsonBuffer;
+  JsonObject root = jsonBuffer.to<JsonObject>();
+  root["button"] = true;
+
+  // Send the state to Losant.
+  device.sendState(root);
+}
+
+int buttonState = 0;
+
+void loop() {
+
+  bool toReconnect = false;
+
+  if(WiFi.status() != WL_CONNECTED) {
+    Serial.println("Disconnected from WiFi");
+    toReconnect = true;
+  }
+
+  if(!device.connected()) {
+    Serial.println("Disconnected from Losant");
+    toReconnect = true;
+  }
+
+  if(toReconnect) {
+    connect();
+  }
+
+  device.loop();
+
+  int currentRead = digitalRead(BUTTON_PIN);
+
+  if(currentRead != buttonState) {
+    buttonState = currentRead;
+    if(buttonState) {
+      buttonPressed();
+    }
+  }
+
+  delay(100);
+}

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/Losant/losant-mqtt-arduino.git"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "dependencies":
   [
     {
@@ -16,7 +16,8 @@
       "frameworks": "arduino"
     },
     {
-      "name": "PubSubClient",
+      "name": "MQTT",
+      "authors": "Joel Gahwiler",
       "frameworks": "arduino"
     }
   ],

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/Losant/losant-mqtt-arduino.git"
   },
-  "version": "1.4.0",
+  "version": "2.0.0",
   "dependencies":
   [
     {

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=losant-mqtt-arduino
-version=1.3.0
+version=1.4.0
 author=Brandon Cannaday <brandon@losant.com>, Adam Daniel <adam@losant.com>
 maintainer=Brandon Cannaday <brandon@losant.com>
 sentence=MQTT library to easily communicate with the Losant IoT platform.
-paragraph=Wraps knolleary's pubsubclient for MQTT communication.
+paragraph=Wraps Joël Gähwiler's MQTT Client for MQTT communication.
 category=Communication
-url=https://github.com/Losant/losant-mqtt-arduino
+url=https://github.com/256dpi/arduino-mqtt
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=Wraps Joël Gähwiler's MQTT Client for MQTT communication.
 category=Communication
 url=https://github.com/Losant/losant-mqtt-arduino
 architectures=*
+depends=MQTT,ArduinoJson

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=losant-mqtt-arduino
-version=1.4.0
+version=2.0.0
 author=Brandon Cannaday <brandon@losant.com>, Adam Daniel <adam@losant.com>
 maintainer=Brandon Cannaday <brandon@losant.com>
 sentence=MQTT library to easily communicate with the Losant IoT platform.
 paragraph=Wraps Joël Gähwiler's MQTT Client for MQTT communication.
 category=Communication
-url=https://github.com/256dpi/arduino-mqtt
+url=https://github.com/Losant/losant-mqtt-arduino
 architectures=*

--- a/src/internal/LosantDevice.cpp
+++ b/src/internal/LosantDevice.cpp
@@ -5,10 +5,9 @@ MQTTClient mqttClient(MQTT_MAX_PACKET_SIZE);
 
 CommandCallback LosantDevice::commandCallback = NULL;
 
-void commandReceived(char* topic, byte* payload, unsigned int length) {
+void commandReceived(String &topic, String &payload) {
 
   LosantCommand command;
-  DynamicJsonBuffer jsonBuffer;
   DynamicJsonDocument root(1024);
   DeserializationError error = deserializeJson(root, payload);
 

--- a/src/internal/LosantDevice.cpp
+++ b/src/internal/LosantDevice.cpp
@@ -1,7 +1,4 @@
-#include <MQTT.h>
 #include "LosantDevice.h"
-
-MQTTClient mqttClient(MQTT_MAX_PACKET_SIZE);
 
 CommandCallback LosantDevice::commandCallback = NULL;
 

--- a/src/internal/LosantDevice.cpp
+++ b/src/internal/LosantDevice.cpp
@@ -98,7 +98,5 @@ void LosantDevice::sendState(JsonObject& state) {
   String stateStr;
   serializeJson(doc, stateStr);
 
-  Serial.println(stateStr);
-
   mqttClient.publish(this->stateTopic.c_str(), stateStr.c_str());
 }

--- a/src/internal/LosantDevice.cpp
+++ b/src/internal/LosantDevice.cpp
@@ -1,4 +1,7 @@
+#include <MQTT.h>
 #include "LosantDevice.h"
+
+MQTTClient mqttClient(MQTT_MAX_PACKET_SIZE);
 
 CommandCallback LosantDevice::commandCallback = NULL;
 
@@ -6,12 +9,14 @@ void commandReceived(char* topic, byte* payload, unsigned int length) {
 
   LosantCommand command;
   DynamicJsonBuffer jsonBuffer;
-  JsonObject& root = jsonBuffer.parseObject((char*)payload);
+  DynamicJsonDocument root(1024);
+  DeserializationError error = deserializeJson(root, payload);
 
-  if(root.success()) {
+  if (!error) {
     command.name = root["name"];
     command.time = root["$time"];
-    command.payload = &(root["payload"].asObject());
+    JsonObject object = root["payload"].to<JsonObject>();
+    command.payload = &object;
 
     LosantDevice::commandCallback(&command);
   }
@@ -62,10 +67,9 @@ void LosantDevice::connect(Client &client, const char* key, const char* secret, 
     return;
   }
 
-  mqttClient.setClient(client);
-  mqttClient.setServer(brokerUrl, brokerPort);
+  mqttClient.begin(brokerUrl, brokerPort, client);
+  mqttClient.onMessage(commandReceived);
   mqttClient.connect(this->id, key, secret);
-  mqttClient.setCallback(commandReceived);
   int topicLen = commandTopic.length() + 1;
   char topicBuf[topicLen];
   commandTopic.toCharArray(topicBuf, topicLen);
@@ -87,13 +91,14 @@ boolean LosantDevice::loop() {
 void LosantDevice::sendState(JsonObject& state) {
 
   // Create a wrapper object and add provided state to "data" property.
-  StaticJsonBuffer<100> jsonBuffer;
-  JsonObject& root = jsonBuffer.createObject();
-  root["data"] = state;
+  StaticJsonDocument<256> doc;
+  doc["data"] = state;
 
   // Convert to string to send over mqtt.
   String stateStr;
-  root.printTo(stateStr);
+  serializeJson(doc, stateStr);
+
+  Serial.println(stateStr);
 
   mqttClient.publish(this->stateTopic.c_str(), stateStr.c_str());
 }

--- a/src/internal/LosantDevice.h
+++ b/src/internal/LosantDevice.h
@@ -2,11 +2,15 @@
 #ifndef LOSANT_DEVICE_H_
 #define LOSANT_DEVICE_H_
 
-#include <PubSubClient.h>
 #include <ArduinoJson.h>
 #include "Client.h"
 #include "Losant.h"
 #include "LosantCommand.h"
+
+// MQTT_MAX_PACKET_SIZE : Maximum packet size
+#ifndef MQTT_MAX_PACKET_SIZE
+#define MQTT_MAX_PACKET_SIZE 256
+#endif
 
 typedef void (*CommandCallback)(LosantCommand*);
 
@@ -26,7 +30,6 @@ class LosantDevice {
 		String stateTopic;
 		String commandTopic;
 		static CommandCallback commandCallback;
-		PubSubClient mqttClient;
 	private:
 		const char* id;
 		void setTopics();

--- a/src/internal/LosantDevice.h
+++ b/src/internal/LosantDevice.h
@@ -2,6 +2,7 @@
 #ifndef LOSANT_DEVICE_H_
 #define LOSANT_DEVICE_H_
 
+#include <MQTT.h>
 #include <ArduinoJson.h>
 #include "Client.h"
 #include "Losant.h"
@@ -30,6 +31,7 @@ class LosantDevice {
 		String stateTopic;
 		String commandTopic;
 		static CommandCallback commandCallback;
+		MQTTClient mqttClient = MQTTClient(MQTT_MAX_PACKET_SIZE);
 	private:
 		const char* id;
 		void setTopics();


### PR DESCRIPTION
These updates add support for the ArduinoJson version 6 library. 

Change from the PubSubClient to the more maintained MQTT Client library which corrects default packet size, secure connection issues, and a couple Arduino board updates (e.g. ESP8266WiFi).

Breaking Changes:

- Client state `device.mqttClient.state()` is no longer supported.
- Constructing MQTT state JSON object is now in the ArduionJson version 6 form.

Old:
```
StaticJsonBuffer<200> jsonBuffer;
JsonObject& root = jsonBuffer.createObject();
```
New:
```
StaticJsonDocument<200> doc;
JsonObject root = doc.to<JsonObject>();
```